### PR TITLE
fix: Xcode 12 compatibility

### DIFF
--- a/react-native-version-info.podspec
+++ b/react-native-version-info.podspec
@@ -12,6 +12,6 @@ Pod::Spec.new do |s|
   s.platform       = :ios, "7.0"
   s.source         = { :git => "#{package_json["repository"]["url"]}", :tag => "#{s.version}" }
   s.source_files   = 'ios/*.{h,m}'
-  s.dependency 'React'
+  s.dependency 'React-Core'
 
 end


### PR DESCRIPTION
Latest Xcode 12 fails to build without a module to depend on `React-Core` directly hence this change is necessary for all native modules on iOS. This change requires React Native 0.60.2 or newer. For more details please check: https://github.com/facebook/react-native/issues/29633#issuecomment-694187116